### PR TITLE
Fix index launch and persist reservations

### DIFF
--- a/project/index.html
+++ b/project/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/project/index.html
+++ b/project/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/project/src/components/Admin/AdminPage.tsx
+++ b/project/src/components/Admin/AdminPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, Edit, Trash2, Save, X, MapPin, Clock, Users, DollarSign, Image } from 'lucide-react';
+import { Plus, Edit, Trash2, Save, X, MapPin, Image } from 'lucide-react';
 import { useApp } from '../../context/AppContext';
 import { Field } from '../../types';
 

--- a/project/src/components/Fields/FieldsPage.tsx
+++ b/project/src/components/Fields/FieldsPage.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useMemo } from 'react';
-import { MapPin, Clock, Star, Users, Filter, X } from 'lucide-react';
+import React, { useMemo } from 'react';
+import { MapPin, Clock, Star, Users, X } from 'lucide-react';
 import { useApp } from '../../context/AppContext';
 import { Field } from '../../types';
 
@@ -9,7 +9,6 @@ interface FieldsPageProps {
 
 export function FieldsPage({ onFieldSelect }: FieldsPageProps) {
   const { fields, searchFilters, updateSearchFilters } = useApp();
-  const [showFilters, setShowFilters] = useState(false);
 
   const neighborhoods = [...new Set(fields.map(field => field.neighborhood))];
 

--- a/project/src/components/Home/HomePage.tsx
+++ b/project/src/components/Home/HomePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Search, MapPin, Clock, Star, TrendingUp, Calendar } from 'lucide-react';
+import { MapPin, Clock, Star, TrendingUp, Calendar } from 'lucide-react';
 import { useApp } from '../../context/AppContext';
 
 interface HomePageProps {
@@ -7,7 +7,7 @@ interface HomePageProps {
 }
 
 export function HomePage({ onPageChange }: HomePageProps) {
-  const { fields, searchFilters, updateSearchFilters } = useApp();
+  const { fields, updateSearchFilters } = useApp();
 
   const featuredFields = fields.slice(0, 3);
 

--- a/project/src/context/AppContext.tsx
+++ b/project/src/context/AppContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, Field, Reservation, SearchFilters } from '../types';
 
 interface AppContextType {
@@ -96,9 +96,15 @@ const mockFields: Field[] = [
 ];
 
 export function AppProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<User | null>(() => {
+    const stored = localStorage.getItem("user");
+    return stored ? JSON.parse(stored) : null;
+  });
   const [fields, setFields] = useState<Field[]>(mockFields);
-  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [reservations, setReservations] = useState<Reservation[]>(() => {
+    const stored = localStorage.getItem("reservations");
+    return stored ? JSON.parse(stored) : [];
+  });
   const [searchFilters, setSearchFilters] = useState<SearchFilters>({
     query: '',
     type: '',
@@ -108,8 +114,20 @@ export function AppProvider({ children }: { children: ReactNode }) {
     maxPrice: 200
   });
   const [isLoading, setIsLoading] = useState(false);
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem("user", JSON.stringify(user));
+    } else {
+      localStorage.removeItem("user");
+    }
+  }, [user]);
 
-  const login = async (email: string, password: string): Promise<boolean> => {
+  useEffect(() => {
+    localStorage.setItem("reservations", JSON.stringify(reservations));
+  }, [reservations]);
+
+
+  const login = async (email: string): Promise<boolean> => {
     setIsLoading(true);
     // Mock login logic
     await new Promise(resolve => setTimeout(resolve, 1000));

--- a/project/vite.config.ts
+++ b/project/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- make index.html script path relative so direct opening works
- persist user and reservations in localStorage
- clean up unused imports and variables

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f420af7a08332b76b00b0ba53ee4f